### PR TITLE
feat: log when ERA5 download fails due MultiAdaptorError

### DIFF
--- a/agera5tools/build.py
+++ b/agera5tools/build.py
@@ -96,11 +96,16 @@ def download_one_month(input):
     cds_query.update(cds_variable_details)
 
     download_fname = config.data_storage.tmp_path / f"cds_download_{uuid4()}.zip"
-    c = cdsapi.Client(quiet=True)
-    c.retrieve('sis-agrometeorological-indicators', cds_query, download_fname)
+    logger = logging.getLogger(__name__)
+
+    try:
+        c = cdsapi.Client(quiet=True)
+        c.retrieve('sis-agrometeorological-indicators', cds_query, download_fname)
+    except Exception as e:
+        logger.error(e)
+        exit(-1)
 
     msg = f"Downloaded data for {agera5_variable_name} for {year}-{month:02} to {download_fname}."
-    logger = logging.getLogger(__name__)
     logger.debug(msg)
 
     return dict(year=year, month=month, varname=agera5_variable_name, download_fname=download_fname)


### PR DESCRIPTION
In some cases, the request for AgERA5 data fails due to a MultiAdaptorError:

```
The job has failed.
Your request has not found any data, please check your selection.
This may be due to temporary connectivity issues with the source data.
If this problem persists, please contact user support.
Your request has not found any data, please check your selection.
This may be due to temporary connectivity issues with the source data.
If this problem persists, please contact user support.
The job failed with: MultiAdaptorNoDataError
```

This failure, however, was not logged and only written to the console. While this PR does not fix the `MultiAdaptorNoDataError` (my suspicion is it has something do with the CDS server rather than the client), it makes it at least easier to log and spot.
